### PR TITLE
removed the '/control' parameter for the mstsc command

### DIFF
--- a/lib/rdp-connect.js
+++ b/lib/rdp-connect.js
@@ -20,7 +20,7 @@ function deleteRdpFile(filePath) {
 
 function connect(config, filePath) {
   var deferred = Q.defer();
-  var proc = spawn('mstsc.exe', [filePath, '/admin', '/control', '/v', config.address]);
+  var proc = spawn('mstsc.exe', [filePath, '/admin', '/v', config.address]);
   // when the process is closed, return the control to the pipe
   proc.on('exit', function() {
     deferred.resolve(true);


### PR DESCRIPTION
I got always syntax errors on Windows 7 until I removed the control parameter. This one seems to be no longer supported - see [Microsoft documentation](https://technet.microsoft.com/de-de/library/cc753907%28v=ws.10%29.aspx)
